### PR TITLE
Add clean script to be used before build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 testando
 package-lock.json
+yarn.lock
 bin/*

--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,23 @@
+var fs = require("fs");
+
+function removeBuildFolder(path) {
+    if (fs.existsSync(path) && fs.lstatSync(path).isDirectory()) {
+        fs.readdirSync(path).forEach(function(file) {
+            var curPath = path + "/" + file;
+
+            if (fs.lstatSync(curPath).isDirectory()) {
+                removeBuildFolder(curPath);
+            } else {
+                fs.unlinkSync(curPath);
+            }
+        });
+
+        fs.rmdirSync(path);
+    }
+}
+
+console.log("Cleaning build folder...");
+
+removeBuildFolder("./bin");
+
+console.log("Successfully cleaned build folder!");

--- a/clean.js
+++ b/clean.js
@@ -3,7 +3,7 @@ var fs = require("fs");
 function removeBuildFolder(path) {
     if (fs.existsSync(path) && fs.lstatSync(path).isDirectory()) {
         fs.readdirSync(path).forEach(function(file) {
-            var curPath = path + "/" + file;
+            const curPath = path + "/" + file;
 
             if (fs.lstatSync(curPath).isDirectory()) {
                 removeBuildFolder(curPath);

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-  "name": "react-drab",
-  "version": "1.0.3",
-  "description": "CLI to improve your productivity using ReactJS",
-  "dependencies": {
-    "@types/node": "^12.12.5",
-    "chalk": "^2.4.2",
-    "cli-table": "^0.3.1",
-    "colors": "^1.4.0",
-    "figlet": "^1.2.4",
-    "inquirer": "^7.0.0",
-    "json-beautify": "^1.1.1",
-    "minimist": "^1.2.0",
-    "shelljs": "^0.8.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/filipemacedo/react-drab.git"
-  },
-  "bugs": {
-    "url": "https://github.com/filipemacedo/react-drab/issues"
-  },
-  "homepage": "https://github.com/filipemacedo/react-drab/",
-  "keywords": [
-    "ReactJS CLI",
-    "CLI ReactJS",
-    "Reactjs cli",
-    "Fast development react"
-  ],
-  "bin": {
-    "react-drab": "./bin/index.js"
-  },
-  "devDependencies": {
-    "typescript": "^3.7.2"
-  },
-  "scripts": {
-    "build": "./node_modules/.bin/tsc"
-  },
-  "author": "Filipe Macedo",
-  "license": "ISC"
+    "name": "react-drab",
+    "version": "1.0.3",
+    "description": "CLI to improve your productivity using ReactJS",
+    "dependencies": {
+        "@types/node": "^12.12.5",
+        "chalk": "^2.4.2",
+        "cli-table": "^0.3.1",
+        "colors": "^1.4.0",
+        "figlet": "^1.2.4",
+        "inquirer": "^7.0.0",
+        "json-beautify": "^1.1.1",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.3"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/filipemacedo/react-drab.git"
+    },
+    "bugs": {
+        "url": "https://github.com/filipemacedo/react-drab/issues"
+    },
+    "homepage": "https://github.com/filipemacedo/react-drab/",
+    "keywords": [
+        "ReactJS CLI",
+        "CLI ReactJS",
+        "Reactjs cli",
+        "Fast development react"
+    ],
+    "bin": {
+        "react-drab": "./bin/index.js"
+    },
+    "devDependencies": {
+        "typescript": "^3.7.2"
+    },
+    "scripts": {
+        "prebuild": "yarn clean",
+        "build": "./node_modules/.bin/tsc",
+        "clean": "node clean.js"
+    },
+    "author": "Filipe Macedo",
+    "license": "ISC"
 }


### PR DESCRIPTION
The intent of this script is to remove the bin folder, in a cross-platform way, before running the build command. Before this script the user received an error when running the build script for the second time, needing to manually remove the folder.