### PR TITLE
Add babel for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 testando
 package-lock.json
+yarn.lock
 bin/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+	"singleQuote": true,
+	"printWidth": 100,
+	"proseWrap": "always",
+	"tabWidth": 2,
+	"useTabs": true,
+	"trailingComma": "es5"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	presets: ['@babel/preset-typescript', '@babel/preset-env'],
+	plugins: [
+		[
+			'@babel/plugin-transform-runtime',
+			{
+				regenerator: true,
+			},
+		],
+	],
+};

--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,23 @@
+var fs = require("fs");
+
+function removeBuildFolder(path) {
+    if (fs.existsSync(path) && fs.lstatSync(path).isDirectory()) {
+        fs.readdirSync(path).forEach(function(file) {
+            var curPath = path + "/" + file;
+
+            if (fs.lstatSync(curPath).isDirectory()) {
+                removeBuildFolder(curPath);
+            } else {
+                fs.unlinkSync(curPath);
+            }
+        });
+
+        fs.rmdirSync(path);
+    }
+}
+
+console.log("Cleaning build folder...");
+
+removeBuildFolder("./bin");
+
+console.log("Successfully cleaned build folder!");

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-  "name": "react-drab",
-  "version": "1.0.3",
-  "description": "CLI to improve your productivity using ReactJS",
-  "dependencies": {
-    "@types/node": "^12.12.5",
-    "chalk": "^2.4.2",
-    "cli-table": "^0.3.1",
-    "colors": "^1.4.0",
-    "figlet": "^1.2.4",
-    "inquirer": "^7.0.0",
-    "json-beautify": "^1.1.1",
-    "minimist": "^1.2.0",
-    "shelljs": "^0.8.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/filipemacedo/react-drab.git"
-  },
-  "bugs": {
-    "url": "https://github.com/filipemacedo/react-drab/issues"
-  },
-  "homepage": "https://github.com/filipemacedo/react-drab/",
-  "keywords": [
-    "ReactJS CLI",
-    "CLI ReactJS",
-    "Reactjs cli",
-    "Fast development react"
-  ],
-  "bin": {
-    "react-drab": "./bin/index.js"
-  },
-  "devDependencies": {
-    "typescript": "^3.7.2"
-  },
-  "scripts": {
-    "build": "./node_modules/.bin/tsc"
-  },
-  "author": "Filipe Macedo",
-  "license": "ISC"
+    "name": "react-drab",
+    "version": "1.0.3",
+    "description": "CLI to improve your productivity using ReactJS",
+    "dependencies": {
+        "@types/node": "^12.12.5",
+        "chalk": "^2.4.2",
+        "cli-table": "^0.3.1",
+        "colors": "^1.4.0",
+        "figlet": "^1.2.4",
+        "inquirer": "^7.0.0",
+        "json-beautify": "^1.1.1",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.3"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/filipemacedo/react-drab.git"
+    },
+    "bugs": {
+        "url": "https://github.com/filipemacedo/react-drab/issues"
+    },
+    "homepage": "https://github.com/filipemacedo/react-drab/",
+    "keywords": [
+        "ReactJS CLI",
+        "CLI ReactJS",
+        "Reactjs cli",
+        "Fast development react"
+    ],
+    "bin": {
+        "react-drab": "./bin/index.js"
+    },
+    "devDependencies": {
+        "typescript": "^3.7.2"
+    },
+    "scripts": {
+        "prebuild": "yarn clean",
+        "build": "./node_modules/.bin/tsc",
+        "clean": "node clean.js"
+    },
+    "author": "Filipe Macedo",
+    "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,19 @@
 		"react-drab": "./bin/index.js"
 	},
 	"devDependencies": {
+		"@babel/cli": "^7.7.4",
+		"@babel/core": "^7.7.4",
+		"@babel/plugin-transform-runtime": "^7.7.4",
+		"@babel/preset-env": "^7.7.4",
+		"@babel/preset-typescript": "^7.7.4",
+		"@babel/runtime": "^7.7.4",
 		"prettier": "1.19.1",
 		"typescript": "^3.7.2"
 	},
 	"scripts": {
-		"prebuild": "yarn clean",
-		"build": "./node_modules/.bin/tsc",
+		"prebuild": "yarn clean && yarn tsc",
+		"build": "babel src --out-dir bin --extensions '.ts' --copy-files",
+		"tsc": "./node_modules/.bin/tsc",
 		"clean": "node clean.js",
 		"lint": "prettier --write src/**/*.ts"
 	},

--- a/package.json
+++ b/package.json
@@ -1,43 +1,45 @@
 {
-    "name": "react-drab",
-    "version": "1.0.3",
-    "description": "CLI to improve your productivity using ReactJS",
-    "dependencies": {
-        "@types/node": "^12.12.5",
-        "chalk": "^2.4.2",
-        "cli-table": "^0.3.1",
-        "colors": "^1.4.0",
-        "figlet": "^1.2.4",
-        "inquirer": "^7.0.0",
-        "json-beautify": "^1.1.1",
-        "minimist": "^1.2.0",
-        "shelljs": "^0.8.3"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/filipemacedo/react-drab.git"
-    },
-    "bugs": {
-        "url": "https://github.com/filipemacedo/react-drab/issues"
-    },
-    "homepage": "https://github.com/filipemacedo/react-drab/",
-    "keywords": [
-        "ReactJS CLI",
-        "CLI ReactJS",
-        "Reactjs cli",
-        "Fast development react"
-    ],
-    "bin": {
-        "react-drab": "./bin/index.js"
-    },
-    "devDependencies": {
-        "typescript": "^3.7.2"
-    },
-    "scripts": {
-        "prebuild": "yarn clean",
-        "build": "./node_modules/.bin/tsc",
-        "clean": "node clean.js"
-    },
-    "author": "Filipe Macedo",
-    "license": "ISC"
+	"name": "react-drab",
+	"version": "1.0.3",
+	"description": "CLI to improve your productivity using ReactJS",
+	"dependencies": {
+		"@types/node": "^12.12.5",
+		"chalk": "^2.4.2",
+		"cli-table": "^0.3.1",
+		"colors": "^1.4.0",
+		"figlet": "^1.2.4",
+		"inquirer": "^7.0.0",
+		"json-beautify": "^1.1.1",
+		"minimist": "^1.2.0",
+		"shelljs": "^0.8.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/filipemacedo/react-drab.git"
+	},
+	"bugs": {
+		"url": "https://github.com/filipemacedo/react-drab/issues"
+	},
+	"homepage": "https://github.com/filipemacedo/react-drab/",
+	"keywords": [
+		"ReactJS CLI",
+		"CLI ReactJS",
+		"Reactjs cli",
+		"Fast development react"
+	],
+	"bin": {
+		"react-drab": "./bin/index.js"
+	},
+	"devDependencies": {
+		"prettier": "1.19.1",
+		"typescript": "^3.7.2"
+	},
+	"scripts": {
+		"prebuild": "yarn clean",
+		"build": "./node_modules/.bin/tsc",
+		"clean": "node clean.js",
+		"lint": "prettier --write src/**/*.ts"
+	},
+	"author": "Filipe Macedo",
+	"license": "ISC"
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,21 +1,17 @@
-import help from "./help";
+import help from './help';
 
-import component from "./component";
-import page from "./page";
-import service from "./service";
-import hook from "./hook";
-import {
-  argvType,
-  CommandTerminatedType,
-  CommandsFunctionType
-} from "../types/commands.type";
+import component from './component';
+import page from './page';
+import service from './service';
+import hook from './hook';
+import { argvType, CommandTerminatedType, CommandsFunctionType } from '../types/commands.type';
 
 const commands: CommandsFunctionType[] = [help, component, page, service, hook];
 
 export default (argv: argvType) => {
-  for (let command of commands) {
-    const { done } = <CommandTerminatedType>command(argv);
+	for (let command of commands) {
+		const { done } = <CommandTerminatedType>command(argv);
 
-    if (done) break;
-  }
+		if (done) break;
+	}
 };

--- a/src/helpers/apply-kebab-when-upper-case.ts
+++ b/src/helpers/apply-kebab-when-upper-case.ts
@@ -1,8 +1,8 @@
 export default (words: string[]): string =>
-  words.reduce((p: string, c: string) => {
-    const isCapital = c.match(/[A-Z]/);
+	words.reduce((p: string, c: string) => {
+		const isCapital = c.match(/[A-Z]/);
 
-    if (!p.length) return c;
+		if (!p.length) return c;
 
-    return isCapital ? `${p}-${c}` : `${p}${c}`;
-  }, "");
+		return isCapital ? `${p}-${c}` : `${p}${c}`;
+	}, '');

--- a/src/helpers/command-terminated.ts
+++ b/src/helpers/command-terminated.ts
@@ -1,4 +1,4 @@
-import { CommandTerminatedType } from "../types/commands.type";
+import { CommandTerminatedType } from '../types/commands.type';
 
 export const finished = (): CommandTerminatedType => ({ done: true });
 export const notFinished = (): CommandTerminatedType => ({ done: false });

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,19 +1,18 @@
-const fs = require("fs");
+const fs = require('fs');
 
 type ConfigType = {
-  extension: "js" | "ts";
-  components: string;
-  services: string;
-  hooks: string;
-  pages: string;
+	extension: 'js' | 'ts';
+	components: string;
+	services: string;
+	hooks: string;
+	pages: string;
 };
 
 const dir: string = process.cwd();
 const dirWithoutConfig = `${dir}/src`;
 const configPath = `${dir}/drab.json`;
 
-const configFile =
-  fs.existsSync(configPath) && fs.readFileSync(`${dir}/drab.json`, "utf8");
+const configFile = fs.existsSync(configPath) && fs.readFileSync(`${dir}/drab.json`, 'utf8');
 
 export const config: ConfigType = configFile && JSON.parse(configFile);
 
@@ -21,32 +20,24 @@ export const config: ConfigType = configFile && JSON.parse(configFile);
  * This function is responsible for get component path
  */
 export const getComponentDirPath: Function = (): string =>
-  config && config.components
-    ? `${dir}/${config.components}`
-    : `${dirWithoutConfig}/components`;
+	config && config.components ? `${dir}/${config.components}` : `${dirWithoutConfig}/components`;
 
 /**
  * This function is responsible for get page path
  */
 export const getPageDirPath: Function = (): string =>
-  config && config.pages
-    ? `${dir}/${config.pages}`
-    : `${dirWithoutConfig}/pages`;
+	config && config.pages ? `${dir}/${config.pages}` : `${dirWithoutConfig}/pages`;
 
 /**
  * This function is responsible for get service path
  */
 export const getServiceDirPath: Function = (): string =>
-  config && config.services
-    ? `${dir}/${config.services}`
-    : `${dirWithoutConfig}/services`;
+	config && config.services ? `${dir}/${config.services}` : `${dirWithoutConfig}/services`;
 
 /**
  * This function is responsible for get hook path
  */
 export const getHookDirPath: Function = (): string =>
-  config && config.hooks
-    ? `${dir}/${config.hooks}`
-    : `${dirWithoutConfig}/hooks`;
+	config && config.hooks ? `${dir}/${config.hooks}` : `${dirWithoutConfig}/hooks`;
 
-export const getExtension: Function = (): string => config.extension || "js";
+export const getExtension: Function = (): string => config.extension || 'js';

--- a/src/helpers/define-component-styles.ts
+++ b/src/helpers/define-component-styles.ts
@@ -1,16 +1,16 @@
-import { ComponentFileType } from "../types/files.type";
+import { ComponentFileType } from '../types/files.type';
 
 export default ({ theme, file, name }: ComponentFileType): string => {
-  const nameLowerCase: string = name.toLowerCase();
-  const pattern: RegExp = /\/\/.+\'\.\/styles\';/g;
+	const nameLowerCase: string = name.toLowerCase();
+	const pattern: RegExp = /\/\/.+\'\.\/styles\';/g;
 
-  if (theme === "none") return file.replace(pattern, "");
-  
-  if (theme === "css" || theme === "scss")
-    return file.replace(pattern, `import './${nameLowerCase}.${theme}';`);
+	if (theme === 'none') return file.replace(pattern, '');
 
-  return file
-    .replace(pattern, `import { Container } from './${nameLowerCase}.styles'`)
-    .replace(/<div \/>/g, "<Container />")
-    .replace(/<div><\/div>/g, "<Container></Container>");
+	if (theme === 'css' || theme === 'scss')
+		return file.replace(pattern, `import './${nameLowerCase}.${theme}';`);
+
+	return file
+		.replace(pattern, `import { Container } from './${nameLowerCase}.styles'`)
+		.replace(/<div \/>/g, '<Container />')
+		.replace(/<div><\/div>/g, '<Container></Container>');
 };

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -1,34 +1,34 @@
-import * as fs from "fs";
+import * as fs from 'fs';
 import {
-  getComponentDirPath,
-  getExtension,
-  getPageDirPath,
-  getServiceDirPath,
-  getHookDirPath
-} from "./config";
-import defineComponentStyles from "./define-component-styles";
+	getComponentDirPath,
+	getExtension,
+	getPageDirPath,
+	getServiceDirPath,
+	getHookDirPath,
+} from './config';
+import defineComponentStyles from './define-component-styles';
 import {
-  TemplateFileType,
-  CreateStyleFileType,
-  ComponentFileType,
-  ComponentType
-} from "../types/files.type";
-import { kebabCase, pascalCase, spaceToPascalCase } from "./string-cases";
+	TemplateFileType,
+	CreateStyleFileType,
+	ComponentFileType,
+	ComponentType,
+} from '../types/files.type';
+import { kebabCase, pascalCase, spaceToPascalCase } from './string-cases';
 
 const templatePath = `${__dirname}/../templates`;
 
 export const createDirIfNotExists = (path: string) => {
-  const [rootDir, ...directories] = path.split("/");
+	const [rootDir, ...directories] = path.split('/');
 
-  return directories.reduce((previous, current) => {
-    const createPath = `${previous}/${current}`;
+	return directories.reduce((previous, current) => {
+		const createPath = `${previous}/${current}`;
 
-    if (!fs.existsSync(createPath)) {
-      fs.mkdirSync(createPath);
-    }
+		if (!fs.existsSync(createPath)) {
+			fs.mkdirSync(createPath);
+		}
 
-    return createPath;
-  }, rootDir);
+		return createPath;
+	}, rootDir);
 };
 
 /**
@@ -36,75 +36,64 @@ export const createDirIfNotExists = (path: string) => {
  * @param param0
  */
 export const readTemplateFile = ({ from, file }: TemplateFileType) =>
-  fs.readFileSync(`${templatePath}/${from}/${file}`, "utf-8");
+	fs.readFileSync(`${templatePath}/${from}/${file}`, 'utf-8');
 
 /**
  *
  */
-export const createComponentDirIfNotExists = () =>
-  createDirIfNotExists(getComponentDirPath());
+export const createComponentDirIfNotExists = () => createDirIfNotExists(getComponentDirPath());
 
 /**
  *
  */
-export const createPageDirIfNotExists = () =>
-  createDirIfNotExists(getPageDirPath());
+export const createPageDirIfNotExists = () => createDirIfNotExists(getPageDirPath());
 
 /**
  *
  */
-export const createServiceDirIfNotExists = () =>
-  createDirIfNotExists(getServiceDirPath());
+export const createServiceDirIfNotExists = () => createDirIfNotExists(getServiceDirPath());
 
-export const createHookDirIfNotExists = () =>
-  createDirIfNotExists(getHookDirPath());
+export const createHookDirIfNotExists = () => createDirIfNotExists(getHookDirPath());
 
 /**
  *
  * @param param0
  */
 const createStyleComponentFile = ({
-  name,
-  path,
-  theme
+	name,
+	path,
+	theme,
 }: CreateStyleFileType & ComponentFileType) => {
-  const nameKebabCase = kebabCase(name);
+	const nameKebabCase = kebabCase(name);
 
-  if (theme === "css" || theme === "scss")
-    return fs.writeFileSync(`${path}/${nameKebabCase}.${theme}`, "");
+	if (theme === 'css' || theme === 'scss')
+		return fs.writeFileSync(`${path}/${nameKebabCase}.${theme}`, '');
 
-  const styledFile = <string>readTemplateFile({
-    file: "styled.js",
-    from: "components"
-  });
+	const styledFile = <string>readTemplateFile({
+		file: 'styled.js',
+		from: 'components',
+	});
 
-  return fs.writeFileSync(
-    `${path}/${nameKebabCase}.styles.${getExtension()}`,
-    styledFile
-  );
+	return fs.writeFileSync(`${path}/${nameKebabCase}.styles.${getExtension()}`, styledFile);
 };
 
 export const createReactComponent = ({ name, type, theme, dirPath }) => {
-  const componentFilePath: string = `${dirPath}/index.${getExtension()}`;
+	const componentFilePath: string = `${dirPath}/index.${getExtension()}`;
 
-  createDirIfNotExists(dirPath);
+	createDirIfNotExists(dirPath);
 
-  const typeFile: string = readTemplateFile({
-    file: `${type}.js`,
-    from: "components"
-  });
+	const typeFile: string = readTemplateFile({
+		file: `${type}.js`,
+		from: 'components',
+	});
 
-  let replacedFile: string = typeFile.replace(
-    /\{componentName\}/g,
-    spaceToPascalCase(name)
-  );
+	let replacedFile: string = typeFile.replace(/\{componentName\}/g, spaceToPascalCase(name));
 
-  replacedFile = <string>(
-    defineComponentStyles({ theme, file: replacedFile, name: kebabCase(name) })
-  );
+	replacedFile = <string>(
+		defineComponentStyles({ theme, file: replacedFile, name: kebabCase(name) })
+	);
 
-  if (theme !== "none")
-    createStyleComponentFile({ name, path: dirPath, theme });
+	if (theme !== 'none') createStyleComponentFile({ name, path: dirPath, theme });
 
-  return fs.writeFileSync(componentFilePath, replacedFile);
+	return fs.writeFileSync(componentFilePath, replacedFile);
 };

--- a/src/helpers/is-command.ts
+++ b/src/helpers/is-command.ts
@@ -1,7 +1,7 @@
 export const isCommand = (args: string[]) => (commands: string[]) => {
-  return !commands
-    .reduce((previous: boolean[], current: string) => {
-      return [...previous, args.includes(current)];
-    }, [])
-    .includes(false);
+	return !commands
+		.reduce((previous: boolean[], current: string) => {
+			return [...previous, args.includes(current)];
+		}, [])
+		.includes(false);
 };

--- a/src/helpers/remove-prompt-name-question.ts
+++ b/src/helpers/remove-prompt-name-question.ts
@@ -1,5 +1,5 @@
 export default (hasName: boolean | string, questions: any[] = []) => {
-  if (hasName) return questions.filter(({ name }) => name !== "name");
+	if (hasName) return questions.filter(({ name }) => name !== 'name');
 
-  return questions;
+	return questions;
 };

--- a/src/helpers/string-cases.ts
+++ b/src/helpers/string-cases.ts
@@ -1,4 +1,4 @@
-import applyKebabWhenUpperCase from "./apply-kebab-when-upper-case";
+import applyKebabWhenUpperCase from './apply-kebab-when-upper-case';
 
 /**
  * This function is responsible for
@@ -9,16 +9,16 @@ import applyKebabWhenUpperCase from "./apply-kebab-when-upper-case";
  * @param isOnlyFirst
  */
 export const transformFirstLetterToUpperCase = (
-  text: any,
-  isOnlyFirst: boolean = false
+	text: any,
+	isOnlyFirst: boolean = false
 ): string => {
-  const [firstLetter, ...othersLetters] = text;
+	const [firstLetter, ...othersLetters] = text;
 
-  const firstLetterDefined: string = firstLetter.toUpperCase();
+	const firstLetterDefined: string = firstLetter.toUpperCase();
 
-  if (isOnlyFirst) return firstLetterDefined;
+	if (isOnlyFirst) return firstLetterDefined;
 
-  return `${firstLetterDefined}${othersLetters.toLowerCase()}`;
+	return `${firstLetterDefined}${othersLetters.toLowerCase()}`;
 };
 
 /**
@@ -29,11 +29,11 @@ export const transformFirstLetterToUpperCase = (
  * @param currentText
  */
 export const pascalCase = (completeText: string, currentText: any): string => {
-  if (currentText.length === 1) return completeText;
+	if (currentText.length === 1) return completeText;
 
-  const text = transformFirstLetterToUpperCase(currentText);
+	const text = transformFirstLetterToUpperCase(currentText);
 
-  return `${completeText}${text}`;
+	return `${completeText}${text}`;
 };
 
 /**
@@ -43,12 +43,11 @@ export const pascalCase = (completeText: string, currentText: any): string => {
  * @param text
  */
 export const spaceToPascalCase = (text: string, forcePascal = false) => {
-  let nameSplit: string[] = text.trim().split(" ");
+	let nameSplit: string[] = text.trim().split(' ');
 
-  if (nameSplit.length > 1 || forcePascal)
-    return nameSplit.reduce(pascalCase, "");
+	if (nameSplit.length > 1 || forcePascal) return nameSplit.reduce(pascalCase, '');
 
-  return text;
+	return text;
 };
 
 /**
@@ -58,18 +57,18 @@ export const spaceToPascalCase = (text: string, forcePascal = false) => {
  * @param text
  */
 export const kebabCase = text => {
-  let textSplit = text.trim().split(" ");
+	let textSplit = text.trim().split(' ');
 
-  if (textSplit.length > 1) return textSplit.join("-");
+	if (textSplit.length > 1) return textSplit.join('-');
 
-  textSplit = text.split(/([A-Z])/g);
-  textSplit = applyKebabWhenUpperCase(textSplit);
+	textSplit = text.split(/([A-Z])/g);
+	textSplit = applyKebabWhenUpperCase(textSplit);
 
-  return textSplit.toLowerCase();
+	return textSplit.toLowerCase();
 };
 
 export const camelCase = text => {
-  const [first, ...others] = text.trim().split(" ");
+	const [first, ...others] = text.trim().split(' ');
 
-  return others.reduce(pascalCase, first);
+	return others.reduce(pascalCase, first);
 };

--- a/src/helpers/verify-if-is-command.ts
+++ b/src/helpers/verify-if-is-command.ts
@@ -1,21 +1,19 @@
-import { CommandTerminatedType, argvType } from "../types/commands.type";
-import { finished, notFinished } from "./command-terminated";
-import { isCommand } from "./is-command";
+import { CommandTerminatedType, argvType } from '../types/commands.type';
+import { finished, notFinished } from './command-terminated';
+import { isCommand } from './is-command';
 
-export default ({ actions, commands }) => (
-  args: argvType
-): CommandTerminatedType => {
-  const { _, help, name, ...props } = <argvType>args;
+export default ({ actions, commands }) => (args: argvType): CommandTerminatedType => {
+	const { _, help, name, ...props } = <argvType>args;
 
-  const isCommandWithArgs: Function = isCommand(_);
+	const isCommandWithArgs: Function = isCommand(_);
 
-  const isDefinedCommand: boolean = isCommandWithArgs(commands);
+	const isDefinedCommand: boolean = isCommandWithArgs(commands);
 
-  if (isDefinedCommand) {
-    actions.create({ help, fileName: name || _[2], ...props });
+	if (isDefinedCommand) {
+		actions.create({ help, fileName: name || _[2], ...props });
 
-    return finished();
-  }
+		return finished();
+	}
 
-  return notFinished();
+	return notFinished();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,23 @@
 #!/usr/bin/env node
 
-import chalk from "chalk";
-import * as figlet from "figlet";
-import * as minimist from "minimist";
-import * as fs from "fs";
-import messages from "./messages";
-import commands from "./commands";
+import chalk from 'chalk';
+import figlet from 'figlet';
+import minimist from 'minimist';
+import commands from './commands';
 
 const argv = minimist(process.argv.slice(2));
 
 type DefaultFigletConfig = {
-  horizontalLayout: string;
-  verticalLayout: string;
+	horizontalLayout: string;
+	verticalLayout: string;
 };
 
 const figletConfigs: DefaultFigletConfig = {
-  horizontalLayout: "default",
-  verticalLayout: "default"
+	horizontalLayout: 'default',
+	verticalLayout: 'default',
 };
 
-const packageName: string = <string>figlet.textSync("DRAB", figletConfigs);
+const packageName: string = <string>figlet.textSync('DRAB', figletConfigs);
 
 console.log(chalk.magenta(packageName));
 

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,12 +1,12 @@
 type MessagesType = {
-  [property: string]: string;
+	[property: string]: string;
 };
 
 /**
- * 
+ *
  */
 export const messages: MessagesType = {
-  welcome: "A command line to aid development with ReactJS\nuse -help to view all commands",
+	welcome: 'A command line to aid development with ReactJS\nuse -help to view all commands',
 };
 
 export default messages;

--- a/src/types/commands.type.ts
+++ b/src/types/commands.type.ts
@@ -1,9 +1,9 @@
 export type argvType = {
-  _: string[];
-  [property: string]: any;
+	_: string[];
+	[property: string]: any;
 };
 
 export type CommandsFunctionType = (args: argvType) => {};
 export type CommandTerminatedType = {
-  done: boolean;
+	done: boolean;
 };

--- a/src/types/component.type.ts
+++ b/src/types/component.type.ts
@@ -1,5 +1,5 @@
 export type ComponentCreateQuestionsType = {
-  name: string;
-  theme: "css" | "styled-components" | "none";
-  type: "rc" | "rrc" | "rsc" | "rrsc" | "rfc";
+	name: string;
+	theme: 'css' | 'styled-components' | 'none';
+	type: 'rc' | 'rrc' | 'rsc' | 'rrsc' | 'rfc';
 };

--- a/src/types/files.type.ts
+++ b/src/types/files.type.ts
@@ -1,18 +1,18 @@
 export type TemplateFileType = {
-  file: string;
-  from: string;
+	file: string;
+	from: string;
 };
 
 export type CreateStyleFileType = {
-  path: string;
+	path: string;
 };
 
 export type ComponentType = {
-  type: string;
+	type: string;
 };
 
 export type ComponentFileType = {
-  name: string;
-  theme: "css" | "styled-components" | "none" | "scss";
-  file?: string;
+	name: string;
+	theme: 'css' | 'styled-components' | 'none' | 'scss';
+	file?: string;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,12 @@
 {
- "compilerOptions": {
-   "target": "es5",           
-   "module": "commonjs",                 
-   "declaration": true,
-   "lib": ["es2018", "dom"],     
-   "outDir": "bin",         
-   "rootDir": "src"      
- },
- "exclude": [
-  "node_modules"
- ]
+	"compilerOptions": {
+		"target": "es5",
+		"module": "commonjs",
+		"declaration": true,
+		"lib": ["es2018", "dom"],
+		"outDir": "bin",
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "src/templates/*"]
 }


### PR DESCRIPTION
The idea here is to use babel + tsc for building the package. This way we can leverage one of babel features that is copying non ts files to the final bundle (templates folder files for example).